### PR TITLE
Add assertions to Parser and MainWindow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,4 +55,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/data/dukeGui.txt
+++ b/data/dukeGui.txt
@@ -1,8 +1,9 @@
 T | 0 | bruh
 E | 1 | something | 2023-10-23T12:34:56 | 2023-10-25T23:59:59
-D | 1 | very important homework | 2023-09-25T12:35:16
+D | 0 | very important homework | 2023-09-25T12:35:16
 T | 0 | study
 T | 0 | bob
 D | 0 | something | 2024-01-01T12:30:45
 D | 0 | ss | 2025-01-01T12:34:56
 E | 1 | test | 2023-10-01T12:00 | 2023-10-02T12:30
+T | 0 | something

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -22,7 +22,7 @@ public class Parser {
      * @throws DukeException If there is an invalid input message causing an error in parsing the MarkCommand.
      */
     private static MarkCommand parseMarkCommand(String message) throws DukeException {
-        // good place for an assert statement
+        assert message.startsWith("mark") : message;
         if (message.length() <= 5) {
             throw new DukeException("You need to specify the index of the task to mark.");
         }
@@ -41,7 +41,7 @@ public class Parser {
      * @throws DukeException If there is an invalid input message causing an error in parsing the UnmarkCommand.
      */
     private static UnmarkCommand parseUnmarkCommand(String message) throws DukeException {
-        // good place for an assert statement
+        assert message.startsWith("unmark") : message;
         if (message.length() <= 7) {
             throw new DukeException("You need to specify the index of the task to unmark.");
         }
@@ -60,7 +60,7 @@ public class Parser {
      * @throws DukeException If there is an invalid input message causing an error in parsing the FindCommand.
      */
     private static FindCommand parseFindCommand(String message) throws DukeException {
-        // good place for an assert statement
+        assert message.startsWith("find") : message;
         if (message.length() <= 5) {
             throw new DukeException("You need to specify the keyword to find the tasks.");
         }
@@ -75,7 +75,7 @@ public class Parser {
      * @throws DukeException If there is an invalid input message causing an error in parsing the DeleteCommand.
      */
     private static DeleteCommand parseDeleteCommand(String message) throws DukeException {
-        // good place for an assert statement
+        assert message.startsWith("delete") : message;
         if (message.length() <= 7) {
             throw new DukeException("You need to specify the index of the task to delete.");
         }
@@ -94,7 +94,7 @@ public class Parser {
      * @throws DukeException If there is an invalid input message causing an error in parsing the AddCommand.
      */
     private static AddCommand parseTodoCommand(String message) throws DukeException {
-        // good place for an assert statement
+        assert message.startsWith("todo") : message;
         if (message.length() <= 5) {
             throw new DukeException("The description of a todo cannot be empty.");
         }
@@ -109,7 +109,7 @@ public class Parser {
      * @throws DukeException If there is an invalid input message causing an error in parsing the AddCommand.
      */
     private static AddCommand parseDeadlineCommand(String message) throws DukeException {
-        // good place for an assert statement
+        assert message.startsWith("deadline") : message;
         if (message.length() <= 9) {
             throw new DukeException("The description of a deadline cannot be empty.");
         }
@@ -128,7 +128,7 @@ public class Parser {
      * @throws DukeException If there is an invalid input message causing an error in parsing the AddCommand.
      */
     private static AddCommand parseEventCommand(String message) throws DukeException {
-        // good place for an assert statement
+        assert message.startsWith("event") : message;
         if (message.length() <= 6) {
             throw new DukeException("The description of an event cannot be empty.");
         }

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -59,6 +59,7 @@ public class MainWindow extends AnchorPane {
      * @param input The input message that triggers this exit handler.
      */
     private void handleExit(String input) {
+        assert input.startsWith("bye") : input;
         // print an exit message, waits 500ms, then exits the program.
         CompletableFuture.completedFuture(dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),
@@ -69,7 +70,7 @@ public class MainWindow extends AnchorPane {
             } catch (InterruptedException e) {
                 Platform.exit();
             }
-        }).thenRunAsync(() -> Platform.exit());
+        }).thenRunAsync(Platform::exit);
     }
 
     /**


### PR DESCRIPTION
To ensure that certain private methods will only be run in certain scenarios, assertions are used to enforce a precondition at the start of the private methods.

Parser class: Ensure that the different commands parsed, as handled by different private methods within the Parser class only happen when the message starts with the corresponding command message. For example, only inputs starting with 'mark' can trigger the parseMarkCommand() private static method in Parser and return a MarkCommand object.

MainWindow class: Ensure that the handleExit() method is only run if the user specifies and types "bye". Checks if the input message starts with "bye".

Gradle is also configured to handle assertions in this commit.