### PR TITLE
Add update and clone functionality

### DIFF
--- a/data/dukeGui.txt
+++ b/data/dukeGui.txt
@@ -1,9 +1,11 @@
 T | 0 | bruh
 E | 1 | something | 2023-10-23T12:34:56 | 2023-10-25T23:59:59
-D | 0 | very important homework | 2023-09-25T12:35:16
+D | 1 | not very important homework | 2023-09-25T12:35:16
 T | 1 | study
-T | 1 | bob
+T | 1 | maxc
 D | 1 | something | 2024-01-01T12:30:45
 D | 0 | ss | 2025-01-01T12:34:56
-E | 1 | test | 2023-10-01T12:00 | 2023-10-02T12:30
+E | 1 | bruh | 2023-10-01T12:00 | 2023-10-10T12:34:56
 T | 0 | something
+T | 0 | maxc
+D | 1 | tt | 2025-01-01T12:34:56

--- a/data/dukeGui.txt
+++ b/data/dukeGui.txt
@@ -9,3 +9,5 @@ E | 1 | bruh | 2023-10-01T12:00 | 2023-10-10T12:34:56
 T | 0 | something
 T | 0 | maxc
 D | 1 | tt | 2025-01-01T12:34:56
+D | 0 | not very important homework | 2023-10-25T12:34:56
+D | 0 | tt | 2025-01-01T12:34:56

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -1,6 +1,15 @@
 package duke;
 
-import duke.command.*;
+import duke.command.AddCommand;
+import duke.command.CloneCommand;
+import duke.command.Command;
+import duke.command.DeleteCommand;
+import duke.command.ExitCommand;
+import duke.command.FindCommand;
+import duke.command.ListCommand;
+import duke.command.MarkCommand;
+import duke.command.UnmarkCommand;
+import duke.command.UpdateCommand;
 import duke.task.UpdateType;
 
 /**
@@ -130,7 +139,7 @@ public class Parser {
         String[] updateDetails = message.substring(7).split(" ");
 
         if (updateDetails.length < 3) {
-            throw new DukeException("You need to specify which task and what to update.");
+            throw new DukeException("You need to specify what to update in the task.");
         }
 
         int updateIndex;
@@ -169,6 +178,10 @@ public class Parser {
         case "deadline":
             // fallthrough
         case "/deadline":
+            // fallthrough
+        case "by":
+            // fallthrough
+        case "/by":
             updateType = UpdateType.DATE1;
             break;
         case "date2":

--- a/src/main/java/duke/command/CloneCommand.java
+++ b/src/main/java/duke/command/CloneCommand.java
@@ -1,0 +1,60 @@
+package duke.command;
+
+import duke.DukeException;
+import duke.Storage;
+import duke.task.TaskList;
+import duke.task.UpdateType;
+
+/**
+ * Represents a command to clone tasks in the task list.
+ */
+public class CloneCommand extends Command {
+
+    /**
+     * The index in the task list to update.
+     */
+    private int index;
+
+    /**
+     * Initialises an UpdateCommand object.
+     *
+     * @param index The index in the task list to clone.
+     */
+    public CloneCommand(int index) {
+        this.index = index;
+    }
+
+    /**
+     * Executes the given UpdateCommand using the specified TaskList and Storage.
+     *
+     * @param tasks The task list to update a task in.
+     * @param storage The storage to save and update tasks.
+     * @return The String that will be passed to the GUI when the UpdateCommand has finished executing.
+     * @throws DukeException If index is out of range for the task list.
+     */
+    @Override
+    public String execute(TaskList tasks, Storage storage) throws DukeException {
+        if (index >= 1 && index <= tasks.getSize()) {
+            StringBuilder responseBuilder = new StringBuilder();
+
+            tasks.cloneTask(index);
+            responseBuilder.append("OK, I've cloned this task:\n");
+            responseBuilder.append("\u2022 " + tasks.getTaskString(index) + "\n");
+            storage.saveTasks(tasks);
+
+            return responseBuilder.toString();
+        } else {
+            throw new DukeException("Cannot clone a task that is out of range!");
+        }
+    }
+
+    /**
+     * Gets the command type for the UpdateCommand.
+     *
+     * @return Update.
+     */
+    @Override
+    public String getCommandType() {
+        return "Update";
+    }
+}

--- a/src/main/java/duke/command/CloneCommand.java
+++ b/src/main/java/duke/command/CloneCommand.java
@@ -3,7 +3,6 @@ package duke.command;
 import duke.DukeException;
 import duke.Storage;
 import duke.task.TaskList;
-import duke.task.UpdateType;
 
 /**
  * Represents a command to clone tasks in the task list.
@@ -16,7 +15,7 @@ public class CloneCommand extends Command {
     private int index;
 
     /**
-     * Initialises an UpdateCommand object.
+     * Initialises a CloneCommand object.
      *
      * @param index The index in the task list to clone.
      */
@@ -25,11 +24,11 @@ public class CloneCommand extends Command {
     }
 
     /**
-     * Executes the given UpdateCommand using the specified TaskList and Storage.
+     * Executes the given CloneCommand using the specified TaskList and Storage.
      *
-     * @param tasks The task list to update a task in.
+     * @param tasks The task list to clone a task in.
      * @param storage The storage to save and update tasks.
-     * @return The String that will be passed to the GUI when the UpdateCommand has finished executing.
+     * @return The String that will be passed to the GUI when the CloneCommand has finished executing.
      * @throws DukeException If index is out of range for the task list.
      */
     @Override
@@ -49,12 +48,12 @@ public class CloneCommand extends Command {
     }
 
     /**
-     * Gets the command type for the UpdateCommand.
+     * Gets the command type for the CloneCommand.
      *
-     * @return Update.
+     * @return Clone.
      */
     @Override
     public String getCommandType() {
-        return "Update";
+        return "Clone";
     }
 }

--- a/src/main/java/duke/command/UpdateCommand.java
+++ b/src/main/java/duke/command/UpdateCommand.java
@@ -1,0 +1,74 @@
+package duke.command;
+
+import duke.DukeException;
+import duke.Storage;
+import duke.task.TaskList;
+import duke.task.UpdateType;
+
+/**
+ * Represents a command to update the tasks in the task list.
+ */
+public class UpdateCommand extends Command {
+
+    /**
+     * The index in the task list to update.
+     */
+    private int index;
+
+    /**
+     * The part of the task to be updated.
+     */
+    private UpdateType updateType;
+
+    /**
+     * The new value to update to (as a String).
+     */
+    private String newValue;
+
+    /**
+     * Initialises an UpdateCommand object.
+     *
+     * @param index The index in the task list to update.
+     * @param updateType The portion of the task to update.
+     * @param newValue The new value to update to (as a String).
+     */
+    public UpdateCommand(int index, UpdateType updateType, String newValue) {
+        this.index = index;
+        this.updateType = updateType;
+        this.newValue = newValue;
+    }
+
+    /**
+     * Executes the given UpdateCommand using the specified TaskList and Storage.
+     *
+     * @param tasks The task list to update a task in.
+     * @param storage The storage to save and update tasks.
+     * @return The String that will be passed to the GUI when the UpdateCommand has finished executing.
+     * @throws DukeException If index is out of range for the task list.
+     */
+    @Override
+    public String execute(TaskList tasks, Storage storage) throws DukeException {
+        if (index >= 1 && index <= tasks.getSize()) {
+            StringBuilder responseBuilder = new StringBuilder();
+
+            tasks.updateTask(index, updateType, newValue);
+            responseBuilder.append("OK, I've updated this task with the following details:\n");
+            responseBuilder.append("\u2022 " + tasks.getTaskString(index) + "\n");
+            storage.saveTasks(tasks);
+
+            return responseBuilder.toString();
+        } else {
+            throw new DukeException("Cannot update a task that is out of range!");
+        }
+    }
+
+    /**
+     * Gets the command type for the UpdateCommand.
+     *
+     * @return Update.
+     */
+    @Override
+    public String getCommandType() {
+        return "Update";
+    }
+}

--- a/src/main/java/duke/command/UpdateCommand.java
+++ b/src/main/java/duke/command/UpdateCommand.java
@@ -65,10 +65,23 @@ public class UpdateCommand extends Command {
     /**
      * Gets the command type for the UpdateCommand.
      *
-     * @return Update.
+     * @return Update, followed by the update type.
      */
     @Override
     public String getCommandType() {
-        return "Update";
+        switch (updateType) {
+        case DESCRIPTION:
+            return "Update DESCRIPTION";
+            // return statement, no break needed
+        case DATE1:
+            return "Update DATE1";
+            // return statement, no break needed
+        case DATE2:
+            return "Update DATE2";
+            // return statement, no break needed
+        default:
+            throw new AssertionError(updateType);
+            // exception thrown, no break needed
+        }
     }
 }

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -1,7 +1,9 @@
 package duke.task;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
+import duke.DukeException;
 import duke.util.Formatter;
 
 /**
@@ -23,10 +25,40 @@ public class Deadline extends Task {
     }
 
     /**
+     * Updates a deadline task based on the specified update type and value.
+     *
+     * @param type The UpdateType to update the task with.
+     * @param newValue The new value to update the task with.
+     * @throws DukeException If the type and new value parameters are invalid.
+     */
+    @Override
+    public void update(UpdateType type, String newValue) throws DukeException {
+        switch (type) {
+        case DESCRIPTION:
+            message = newValue;
+            break;
+        case DATE1:
+            try {
+                deadline = LocalDateTime.parse(newValue);
+            } catch (DateTimeParseException e) {
+                throw new DukeException("Cannot parse date/time of new deadline!");
+            }
+            break;
+        case DATE2:
+            throw new DukeException("Cannot update: Deadlines have only one deadline date!");
+            // exception thrown, no break statement needed
+        default:
+            throw new DukeException("Invalid update type!");
+            // exception thrown, no break statement needed
+        }
+    }
+
+    /**
      * Returns a String containing information within the Deadline task, formatted to be saved.
      *
      * @return The deadline, formatted as a String to be saved in the save file.
      */
+    @Override
     public String toSaveFormatString() {
         return "D | " + getStatusNumber() + " | " + message + " | " + deadline;
     }
@@ -36,8 +68,14 @@ public class Deadline extends Task {
      *
      * @return The deadline, formatted as a String for output in the application.
      */
+    @Override
     public String toString() {
         return "[D]" + getStatusIcon() + " " + message
                 + " (by: " + Formatter.formatDateTime(deadline) + ")";
+    }
+
+    @Override
+    public Deadline clone() {
+        return new Deadline(message, deadline);
     }
 }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -1,7 +1,9 @@
 package duke.task;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
+import duke.DukeException;
 import duke.util.Formatter;
 
 /**
@@ -26,6 +28,39 @@ public class Event extends Task {
     }
 
     /**
+     * Updates an event task based on the specified update type and value.
+     *
+     * @param type The UpdateType to update the task with.
+     * @param newValue The new value to update the task with.
+     * @throws DukeException If the type and new value parameters are invalid.
+     */
+    @Override
+    public void update(UpdateType type, String newValue) throws DukeException {
+        switch (type) {
+        case DESCRIPTION:
+            message = newValue;
+            break;
+        case DATE1:
+            try {
+                from = LocalDateTime.parse(newValue);
+            } catch (DateTimeParseException e) {
+                throw new DukeException("Cannot parse date/time of new event start date!");
+            }
+            break;
+        case DATE2:
+            try {
+                to = LocalDateTime.parse(newValue);
+            } catch (DateTimeParseException e) {
+                throw new DukeException("Cannot parse date/time of new event end date!");
+            }
+            break;
+        default:
+            throw new DukeException("Invalid update type!");
+            // exception thrown, no break statement needed
+        }
+    }
+
+    /**
      * Returns a String containing information within the Event task, formatted to be saved.
      *
      * @return The event, formatted as a String to be saved in the save file.
@@ -43,5 +78,10 @@ public class Event extends Task {
         return "[E]" + getStatusIcon() + " " + message
                 + " (from: " + Formatter.formatDateTime(from)
                 + " to: " + Formatter.formatDateTime(to) + ")";
+    }
+
+    @Override
+    public Event clone() {
+        return new Event(message, from, to);
     }
 }

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -1,5 +1,7 @@
 package duke.task;
 
+import duke.DukeException;
+
 /**
  * Represents a task, containing a message and whether it is completed or not.
  */
@@ -53,6 +55,14 @@ public abstract class Task {
     }
 
     /**
+     * Updates the given Task with new parameters.
+     * @param type The UpdateType to update the task with.
+     * @param newValue The new value to update the task with.
+     * @throws DukeException If the task is unable to be updated with the new values.
+     */
+    public abstract void update(UpdateType type, String newValue) throws DukeException;
+
+    /**
      * Checks whether the Task message contains a substring.
      *
      * @param substring The substring to search for within the Task message
@@ -64,4 +74,10 @@ public abstract class Task {
 
     public abstract String toSaveFormatString();
     public abstract String toString();
+
+    /**
+     * Clones the internal representation of the task, then returns the new task with the information.
+     * @return The cloned task.
+     */
+    public abstract Task clone();
 }

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import duke.DukeException;
+
 /**
  * Represents a list of tasks (todos/deadlines/events).
  */
@@ -78,6 +80,28 @@ public class TaskList {
                 .map(Task::toSaveFormatString)
                 .collect(Collectors.toList());
     }
+
+    /**
+     * Updates a Task with a specified index.
+     *
+     * @param i The index of the Task to update within the TaskList.
+     * @param updateType The part of the Task to be updated.
+     * @param newValue The new value to put into the updated Task (as a String).
+     */
+    public void updateTask(int i, UpdateType updateType, String newValue) throws DukeException {
+        this.tasks.get(i - 1).update(updateType, newValue);
+    }
+
+    /**
+     * Clones a Task and adds it to the back of the TaskList.
+     *
+     * @param i The index of the Task to clone within the TaskList.
+     */
+    public void cloneTask(int i) {
+        Task toClone = tasks.get(i - 1).clone();
+        tasks.add(toClone);
+    }
+
 
     /**
      * Marks a Task with a specified index as done.

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -1,5 +1,7 @@
 package duke.task;
 
+import duke.DukeException;
+
 /**
  * Represents a todo task, containing a description.
  */
@@ -15,10 +17,35 @@ public class Todo extends Task {
     }
 
     /**
+     * Updates a todo task based on the specified update type and value.
+     *
+     * @param type The UpdateType to update the task with.
+     * @param newValue The new value to update the task with.
+     * @throws DukeException If the type and new value parameters are invalid.
+     */
+    @Override
+    public void update(UpdateType type, String newValue) throws DukeException {
+        switch (type) {
+        case DESCRIPTION:
+            message = newValue;
+            break;
+        case DATE1:
+            // fallthrough
+        case DATE2:
+            throw new DukeException("Cannot update: Todos do not have dates!");
+            // exception thrown, no break statement needed
+        default:
+            throw new DukeException("Invalid update type!");
+            // exception thrown, no break statement needed
+        }
+    }
+
+    /**
      * Returns a String containing information within the Todo task, formatted to be saved.
      *
      * @return The to-do task, formatted as a String to be saved in the save file.
      */
+    @Override
     public String toSaveFormatString() {
         return "T | " + getStatusNumber() + " | " + message;
     }
@@ -28,7 +55,13 @@ public class Todo extends Task {
      *
      * @return The to-do task, formatted as a String for output in the application.
      */
+    @Override
     public String toString() {
         return "[T]" + getStatusIcon() + " " + message;
+    }
+
+    @Override
+    public Todo clone() {
+        return new Todo(message);
     }
 }

--- a/src/main/java/duke/task/UpdateType.java
+++ b/src/main/java/duke/task/UpdateType.java
@@ -1,0 +1,8 @@
+package duke.task;
+
+/**
+ * Specifies the type of updates that can be performed onto the task.
+ */
+public enum UpdateType {
+    DESCRIPTION, DATE1, DATE2
+}

--- a/src/test/java/duke/ParserTest.java
+++ b/src/test/java/duke/ParserTest.java
@@ -131,6 +131,70 @@ public class ParserTest {
     }
 
     @Test
+    public void parse_emptyFindParams_dukeExceptionThrown() {
+        try {
+            Parser.parse("find ");
+            fail();
+        } catch (DukeException e) {
+            assertEquals("You need to specify the keyword to find the tasks.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void parse_emptyUpdateParams_dukeExceptionThrown() {
+        try {
+            Parser.parse("update ");
+            fail();
+        } catch (DukeException e) {
+            assertEquals("You need to specify which task and what to update.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void parse_badUpdateParams_dukeExceptionThrown() {
+        try {
+            Parser.parse("update nothing");
+            fail();
+        } catch (DukeException e) {
+            assertEquals("You need to specify what to update in the task.", e.getMessage());
+        }
+
+        try {
+            Parser.parse("update 23");
+            fail();
+        } catch (DukeException e) {
+            assertEquals("You need to specify what to update in the task.", e.getMessage());
+        }
+
+        try {
+            Parser.parse("update 2 ms message");
+            fail();
+        } catch (DukeException e) {
+            assertEquals("Update type is invalid!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void parse_emptyCloneParams_dukeExceptionThrown() {
+        try {
+            Parser.parse("clone ");
+            fail();
+        } catch (DukeException e) {
+            assertEquals("You need to specify the index of the task to clone.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void parse_badCloneParams_dukeExceptionThrown() {
+        try {
+            Parser.parse("clone test");
+            fail();
+        } catch (DukeException e) {
+            assertEquals("The index of the task to clone is not a valid integer.", e.getMessage());
+        }
+    }
+
+    @Test
     public void parse_exitCommand_success() throws DukeException {
         Command c = Parser.parse("bye");
         assertTrue(c.isExit());
@@ -181,5 +245,52 @@ public class ParserTest {
         Command c = Parser.parse("event some event /from 2023-11-11T12:30:00 /to 2023-11-12T12:00:00");
         assertFalse(c.isExit());
         assertEquals(c.getCommandType(), "Add Event");
+    }
+
+    @Test
+    public void parse_updateDescription_success() throws DukeException {
+        Command[] commands = { Parser.parse("update 3 message something"),
+                Parser.parse("update 3 msg something smells"),
+                Parser.parse("update 3 description whatever df 123") };
+
+        for (Command c : commands) {
+            assertFalse(c.isExit());
+            assertEquals(c.getCommandType(), "Update DESCRIPTION");
+        }
+    }
+
+    @Test
+    public void parse_updateDate1_success() throws DukeException {
+        Command[] commands = { Parser.parse("update 3 /from 2023-11-12T12:00:00"),
+                Parser.parse("update 3 date1 2023-11-12T12:00:00"),
+                Parser.parse("update 3 /by 2023-11-12T12:00:00"),
+                Parser.parse("update 3 by 2023-11-12T12:00:00"),
+                Parser.parse("update 3 from 2023-11-12T12:00:00"),
+                Parser.parse("update 3 /deadline 2023-11-12T12:00:00"),
+                Parser.parse("update 3 deadline 2023-11-12T12:00:00") };
+
+        for (Command c : commands) {
+            assertFalse(c.isExit());
+            assertEquals(c.getCommandType(), "Update DATE1");
+        }
+    }
+
+    @Test
+    public void parse_updateDate2_success() throws DukeException {
+        Command[] commands = { Parser.parse("update 3 /to 2023-11-12T12:00:00"),
+                Parser.parse("update 3 date2 2023-11-12T12:00:00"),
+                Parser.parse("update 3 to 2023-11-12T12:00:00") };
+
+        for (Command c : commands) {
+            assertFalse(c.isExit());
+            assertEquals(c.getCommandType(), "Update DATE2");
+        }
+    }
+
+    @Test
+    public void parse_cloneCommand_success() throws DukeException {
+        Command c = Parser.parse("clone 3");
+        assertFalse(c.isExit());
+        assertEquals(c.getCommandType(), "Clone");
     }
 }

--- a/src/test/java/duke/command/CloneCommandTest.java
+++ b/src/test/java/duke/command/CloneCommandTest.java
@@ -1,0 +1,20 @@
+package duke.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+public class CloneCommandTest {
+    @Test
+    public void testGetCommandType() {
+        CloneCommand c = new CloneCommand(13);
+        assertEquals(c.getCommandType(), "Clone");
+    }
+
+    @Test
+    public void testIsExit() {
+        CloneCommand c = new CloneCommand(13);
+        assertFalse(c.isExit());
+    }
+}

--- a/src/test/java/duke/command/UpdateCommandTest.java
+++ b/src/test/java/duke/command/UpdateCommandTest.java
@@ -1,0 +1,39 @@
+package duke.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+import duke.task.UpdateType;
+
+public class UpdateCommandTest {
+
+    @Test
+    public void getCommandType_description_success() {
+        UpdateCommand u = new UpdateCommand(4, UpdateType.DESCRIPTION, "something");
+        assertEquals("Update DESCRIPTION", u.getCommandType());
+    }
+
+    @Test
+    public void getCommandType_date1_success() {
+        UpdateCommand u = new UpdateCommand(5, UpdateType.DATE1, "2023-10-10T12:34:56");
+        assertEquals("Update DATE1", u.getCommandType());
+    }
+
+    @Test
+    public void getCommandType_date2_success() {
+        UpdateCommand u = new UpdateCommand(3, UpdateType.DATE2, "2023-10-10T12:34:57");
+        assertEquals("Update DATE2", u.getCommandType());
+    }
+
+    @Test
+    public void testIsExit() {
+        UpdateCommand a = new UpdateCommand(4, UpdateType.DESCRIPTION, "something");
+        UpdateCommand b = new UpdateCommand(5, UpdateType.DATE1, "2023-10-10T12:34:56");
+        UpdateCommand c = new UpdateCommand(3, UpdateType.DATE2, "2023-10-10T12:34:57");
+        assertFalse(a.isExit());
+        assertFalse(b.isExit());
+        assertFalse(c.isExit());
+    }
+}

--- a/src/test/java/duke/task/TaskListTest.java
+++ b/src/test/java/duke/task/TaskListTest.java
@@ -1,11 +1,14 @@
 package duke.task;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
+import duke.DukeException;
 
 public class TaskListTest {
     @Test
@@ -104,5 +107,45 @@ public class TaskListTest {
         assertEquals(result.get(2), "D | 0 | Fourth task | 2023-10-10T12:34:58");
         assertEquals(tl.getTaskString(1), "[T][X] First task");
         assertEquals(tl.getTaskString(3), "[D][ ] Fourth task (by: Oct 10 2023, 12:34:58)");
+    }
+
+    @Test
+    public void testUpdateTask() {
+        try {
+            TaskList tl = new TaskList();
+            tl.add(new Todo("First task"));
+            tl.add(new Event("2nd task", LocalDateTime.parse("2023-10-10T12:34:56"),
+                    LocalDateTime.parse("2023-10-10T12:34:57")));
+            tl.add(new Deadline("3rd task", LocalDateTime.parse("2023-10-10T12:34:58")));
+            tl.updateTask(1, UpdateType.DESCRIPTION, "1st task");
+            tl.updateTask(2, UpdateType.DATE2, "2024-01-01T12:00:00");
+            tl.updateTask(3, UpdateType.DATE1, "2024-01-01T12:00:01");
+            tl.markAsDone(3);
+            List<String> result = tl.getSavedStrings();
+            assertEquals(result.get(0), "T | 0 | 1st task");
+            assertEquals(result.get(1), "E | 0 | 2nd task | 2023-10-10T12:34:56 | 2024-01-01T12:00");
+            assertEquals(result.get(2), "D | 1 | 3rd task | 2024-01-01T12:00:01");
+        } catch (DukeException e) {
+            fail("DukeException should not be thrown!");
+        }
+    }
+
+
+    @Test
+    public void testCloneTask() {
+        TaskList tl = new TaskList();
+        tl.add(new Todo("1st task"));
+        tl.add(new Event("2nd task", LocalDateTime.parse("2023-10-10T12:34:56"),
+                LocalDateTime.parse("2023-10-10T12:34:57")));
+        tl.add(new Deadline("3rd task", LocalDateTime.parse("2023-10-10T12:34:58")));
+        tl.markAsDone(2);
+        tl.cloneTask(2);
+        tl.cloneTask(3);
+        List<String> result = tl.getSavedStrings();
+        assertEquals(result.get(0), "T | 0 | 1st task");
+        assertEquals(result.get(1), "E | 1 | 2nd task | 2023-10-10T12:34:56 | 2023-10-10T12:34:57");
+        assertEquals(result.get(2), "D | 0 | 3rd task | 2023-10-10T12:34:58");
+        assertEquals(result.get(3), "E | 0 | 2nd task | 2023-10-10T12:34:56 | 2023-10-10T12:34:57");
+        assertEquals(result.get(4), "D | 0 | 3rd task | 2023-10-10T12:34:58");
     }
 }


### PR DESCRIPTION
The ability to update and clone tasks without deleting them or adding
the details all over again helps the user to improve the ease of use of
the application.

By adding the update functionality, tasks can now be updated using
simple commands such as `update 4 msg Hello World` or `update 3 Deadline
2023-10-10T12:34:56`. This updates the message and deadline for the
tasks respectively. This is done by making the Tasks more mutable and
allowing for updates to be directly done to the task.

By adding the clone functionality, users can add Tasks based on another
task without having to specify the task all over again. This may be
helpful for recurring tasks or related tasks.

These implementations are for the extension **C-Update**.