### PR TITLE
Improve colour appearance in GUI

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -33,14 +33,11 @@ public class Duke {
      * by the Parser.
      * @param message The message to be parsed and executed.
      * @return The text response by the chatbot.
+     * @throws DukeException When there are errors in the response.
      */
-    public String getResponse(String message) {
-        try {
-            Command c = Parser.parse(message);
-            return c.execute(tasks, storage);
-        } catch (DukeException e) {
-            return e.toString();
-        }
+    public String getResponse(String message) throws DukeException {
+        Command c = Parser.parse(message);
+        return c.execute(tasks, storage);
     }
 
     /**

--- a/src/main/java/duke/gui/DialogBox.java
+++ b/src/main/java/duke/gui/DialogBox.java
@@ -7,6 +7,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.SnapshotParameters;
@@ -15,8 +16,12 @@ import javafx.scene.effect.DropShadow;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import javafx.scene.shape.Rectangle;
 
 /**
@@ -78,13 +83,32 @@ public class DialogBox extends HBox {
         setAlignment(Pos.TOP_LEFT);
     }
 
-    public static DialogBox getUserDialog(String text, Image img) {
-        return new DialogBox(text, img);
+    /**
+     * Sets the background of the DialogBox with a certain color.
+     * @param paint The color of the background of the DialogBox to set.
+     */
+    private void fill(Paint paint) {
+        BackgroundFill bgFill = new BackgroundFill(paint,
+                CornerRadii.EMPTY, Insets.EMPTY);
+        Background bg = new Background(bgFill);
+        setBackground(bg);
     }
 
-    public static DialogBox getDukeDialog(String text, Image img) {
+    public static DialogBox getUserDialog(String text, Image img) {
+        DialogBox db = new DialogBox(text, img);
+        db.fill(Color.SILVER);
+        return db;
+    }
+
+    public static DialogBox getDukeDialog(String text, Image img, boolean isError) {
         DialogBox db = new DialogBox(text, img);
         db.flip();
+
+        // set colour of response to red if there are errors
+        if (isError) {
+            db.dialog.setTextFill(Color.DARKRED);
+        }
+
         return db;
     }
 }

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -6,19 +6,13 @@ import duke.Duke;
 import duke.DukeException;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
-import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.VBox;
-import javafx.scene.paint.Color;
-
 /**
  * Controller for MainWindow. Provides the layout for the other controls.
  */

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -3,15 +3,21 @@ package duke.gui;
 import java.util.concurrent.CompletableFuture;
 
 import duke.Duke;
+import duke.DukeException;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
+import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 
 /**
  * Controller for MainWindow. Provides the layout for the other controls.
@@ -50,7 +56,7 @@ public class MainWindow extends AnchorPane {
 
         // print a welcome message
         dialogContainer.getChildren().add(
-                DialogBox.getDukeDialog(duke.getWelcomeMessage(), dukeImage)
+                DialogBox.getDukeDialog(duke.getWelcomeMessage(), dukeImage, false)
         );
     }
 
@@ -63,7 +69,7 @@ public class MainWindow extends AnchorPane {
         // print an exit message, waits 500ms, then exits the program.
         CompletableFuture.completedFuture(dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),
-                DialogBox.getDukeDialog(duke.getExitMessage(), dukeImage)
+                DialogBox.getDukeDialog(duke.getExitMessage(), dukeImage, false)
         )).thenRunAsync(() -> {
             try {
                 Thread.sleep(500);
@@ -75,19 +81,30 @@ public class MainWindow extends AnchorPane {
 
     /**
      * Creates two dialog boxes, one echoing user input and the other containing Duke's reply and then appends them to
-     * the dialog container. Clears the user input after processing.
+     * the dialog container. Clears the user input after processing. If there is an error in input, Duke's reply will
+     * be in dark red.
      */
     @FXML
     private void handleUserInput() {
         String input = userInput.getText();
-        String response = duke.getResponse(input);
+        String response = "";
+        boolean isError = false;
+
+        // try to get a response, else print an error message to be used for Duke's output in the GUI
+        try {
+            response = duke.getResponse(input);
+        } catch (DukeException e) {
+            response = e.toString();
+            isError = true;
+        }
+
         userInput.clear();
 
         // there is a response; do not exit the GUI program
         if (response != null) {
             dialogContainer.getChildren().addAll(
                     DialogBox.getUserDialog(input, userImage),
-                    DialogBox.getDukeDialog(response, dukeImage)
+                    DialogBox.getDukeDialog(response, dukeImage, isError)
             );
         } else {
             handleExit(input);

--- a/src/main/resources/view/DialogBox.fxml
+++ b/src/main/resources/view/DialogBox.fxml
@@ -10,7 +10,7 @@
     <children>
       <Group HBox.hgrow="NEVER">
          <children>
-               <Label fx:id="dialog" layoutY="9.0" maxHeight="1.7976931348623157E308" maxWidth="280.0" text="Label" wrapText="true">
+               <Label fx:id="dialog" layoutY="9.0" maxHeight="1.7976931348623157E308" maxWidth="300.0" text="Label" wrapText="true">
                <padding>
                   <Insets left="5.0" right="5.0" />
                </padding>
@@ -20,7 +20,7 @@
             <Insets />
          </HBox.margin>
       </Group>
-         <ImageView fx:id="displayPicture" fitHeight="80.0" fitWidth="80.0" pickOnBounds="true" preserveRatio="true">
+         <ImageView fx:id="displayPicture" fitHeight="65.0" fitWidth="65.0" pickOnBounds="true" preserveRatio="true">
          <HBox.margin>
             <Insets left="5.0" right="5.0" />
          </HBox.margin></ImageView>


### PR DESCRIPTION
The chatbot so far does not distinguish between error responses by the bot and regular responses. When there is an error response, a dark red reply will be shown by the bot. Dark red is chosen to improve contrast and thus readability of the chatbot.

The background colours are changed to improve distinction between the bot and the human input. The bot has a default colour palette (same as background) while the human input has a silver colour palette.