### PR TITLE
Add test cases for Task subclasses

### DIFF
--- a/data/dukeGui.txt
+++ b/data/dukeGui.txt
@@ -1,14 +1,11 @@
-T | 0 | bruh
+T | 0 | CS2103T tutorial
 E | 1 | something | 2023-10-23T12:34:56 | 2023-10-25T23:59:59
 D | 1 | not very important homework | 2023-09-25T12:35:16
 T | 1 | study
-T | 1 | maxc
+T | 1 | cs2100 homework
 D | 1 | something | 2024-01-01T12:30:45
 D | 0 | ss | 2025-01-01T12:34:56
 E | 1 | bruh | 2023-10-01T12:00 | 2023-10-10T12:34:56
-T | 0 | something
-T | 0 | maxc
-D | 1 | tt | 2025-01-01T12:34:56
 D | 0 | not very important homework | 2023-10-25T12:34:56
 D | 0 | tt | 2025-01-01T12:34:56
 E | 0 | good | 2023-12-31T12:30 | 2023-12-31T12:30:01

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -48,6 +48,7 @@ public class Deadline extends Task {
             throw new DukeException("Cannot update: Deadlines have only one deadline date!");
             // exception thrown, no break statement needed
         default:
+            assert false : "Invalid update type!";
             throw new DukeException("Invalid update type!");
             // exception thrown, no break statement needed
         }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -69,6 +69,7 @@ public class Event extends Task {
             }
             break;
         default:
+            assert false : "Invalid update type!";
             throw new DukeException("Invalid update type!");
             // exception thrown, no break statement needed
         }

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -35,6 +35,7 @@ public class Todo extends Task {
             throw new DukeException("Cannot update: Todos do not have dates!");
             // exception thrown, no break statement needed
         default:
+            assert false : "Invalid update type!";
             throw new DukeException("Invalid update type!");
             // exception thrown, no break statement needed
         }

--- a/src/test/java/duke/task/DeadlineTest.java
+++ b/src/test/java/duke/task/DeadlineTest.java
@@ -1,10 +1,13 @@
 package duke.task;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
+
+import duke.DukeException;
 
 public class DeadlineTest {
 
@@ -31,5 +34,45 @@ public class DeadlineTest {
         assertEquals("[D][ ] Message (by: Dec 13 2023, 12:45:00)", d.toString());
         d.markAsDone();
         assertEquals("[D][X] Message (by: Dec 13 2023, 12:45:00)", d.toString());
+    }
+
+    @Test
+    public void testUpdate_validDate_success() {
+        try {
+            Deadline d = new Deadline("Message",
+                    LocalDateTime.parse("2023-10-10T12:00:00"));
+            d.update(UpdateType.DESCRIPTION, "New Deadline");
+            d.update(UpdateType.DATE1, "2023-10-09T12:34:56");
+            assertEquals("[D][ ] New Deadline (by: Oct 09 2023, 12:34:56)",
+                    d.toString());
+        } catch (DukeException e) {
+            fail("DukeException should not be thrown!");
+        }
+    }
+
+    @Test
+    public void testUpdate_invalidDate_dukeExceptionThrown() {
+        try {
+            Deadline d = new Deadline("Message",
+                    LocalDateTime.parse("2023-10-10T12:00:00"));
+            d.update(UpdateType.DESCRIPTION, "New Deadline");
+            d.update(UpdateType.DATE1, "this is not a date");
+            fail("DukeException should be thrown!");
+        } catch (DukeException e) {
+            assertEquals("Cannot parse date/time of new deadline!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUpdate_invalidUpdateDateType_dukeExceptionThrown() {
+        try {
+            Deadline d = new Deadline("Message",
+                    LocalDateTime.parse("2023-10-10T12:00:00"));
+            d.update(UpdateType.DESCRIPTION, "New Deadline");
+            d.update(UpdateType.DATE2, "2023-10-10T12:00:01");
+            fail("DukeException should be thrown!");
+        } catch (DukeException e) {
+            assertEquals("Cannot update: Deadlines have only one deadline date!", e.getMessage());
+        }
     }
 }

--- a/src/test/java/duke/task/DeadlineTest.java
+++ b/src/test/java/duke/task/DeadlineTest.java
@@ -75,4 +75,23 @@ public class DeadlineTest {
             assertEquals("Cannot update: Deadlines have only one deadline date!", e.getMessage());
         }
     }
+
+    @Test
+    public void testClone() {
+        try {
+            Deadline d = new Deadline("Deadline",
+                    LocalDateTime.parse("2023-10-10T12:00:00"));
+            d.markAsDone();
+            d.update(UpdateType.DESCRIPTION, "New Deadline");
+            Deadline d2 = d.clone();
+            d.update(UpdateType.DESCRIPTION, "Old Deadline");
+            d2.update(UpdateType.DATE1, "2023-10-09T12:34:56");
+            assertEquals("[D][X] Old Deadline (by: Oct 10 2023, 12:00:00)",
+                    d.toString());
+            assertEquals("[D][ ] New Deadline (by: Oct 09 2023, 12:34:56)",
+                    d2.toString());
+        } catch (DukeException e) {
+            fail("DukeException should not be thrown!");
+        }
+    }
 }

--- a/src/test/java/duke/task/EventTest.java
+++ b/src/test/java/duke/task/EventTest.java
@@ -152,4 +152,24 @@ public class EventTest {
             assertEquals("Invalid date parameter: From date must be before to date!", e.getMessage());
         }
     }
+
+    @Test
+    public void testClone() {
+        try {
+            Event ev = new Event("Event",
+                    LocalDateTime.parse("2023-10-10T12:00:00"),
+                    LocalDateTime.parse("2023-10-11T13:30:45"));
+            ev.markAsDone();
+            ev.update(UpdateType.DATE2, "2023-10-10T13:34:56");
+            Event ev2 = ev.clone();
+            ev2.update(UpdateType.DESCRIPTION, "New Event");
+            ev2.update(UpdateType.DATE1, "2023-10-09T12:34:56");
+            assertEquals("[E][X] Event (from: Oct 10 2023, 12:00:00 to: Oct 10 2023, 13:34:56)",
+                    ev.toString());
+            assertEquals("[E][ ] New Event (from: Oct 09 2023, 12:34:56 to: Oct 10 2023, 13:34:56)",
+                    ev2.toString());
+        } catch (DukeException e) {
+            fail("DukeException should not be thrown!");
+        }
+    }
 }

--- a/src/test/java/duke/task/EventTest.java
+++ b/src/test/java/duke/task/EventTest.java
@@ -96,6 +96,35 @@ public class EventTest {
     }
 
     @Test
+    public void testUpdate_invalidDate1_dukeExceptionThrown() {
+        try {
+            Event ev = new Event("Message",
+                    LocalDateTime.parse("2023-10-10T12:00:00"),
+                    LocalDateTime.parse("2023-10-11T13:30:45"));
+            ev.update(UpdateType.DESCRIPTION, "New Event");
+            ev.update(UpdateType.DATE1, "this is not a date");
+            fail("DukeException should be thrown!");
+        } catch (DukeException e) {
+            assertEquals("Cannot parse date/time of new event start date!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUpdate_invalidDate2_dukeExceptionThrown() {
+        try {
+            Event ev = new Event("Message",
+                    LocalDateTime.parse("2023-10-10T12:00:00"),
+                    LocalDateTime.parse("2023-10-11T13:30:45"));
+            ev.update(UpdateType.DESCRIPTION, "New Event");
+            ev.update(UpdateType.DATE2, "this is not a date");
+            fail("DukeException should be thrown!");
+        } catch (DukeException e) {
+            assertEquals("Cannot parse date/time of new event end date!", e.getMessage());
+        }
+    }
+
+
+    @Test
     public void testUpdate_badOrder_dukeExceptionThrown() {
         try {
             Event ev = new Event("Message",

--- a/src/test/java/duke/task/TodoTest.java
+++ b/src/test/java/duke/task/TodoTest.java
@@ -1,8 +1,11 @@
 package duke.task;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
+
+import duke.DukeException;
 
 public class TodoTest {
 
@@ -26,5 +29,41 @@ public class TodoTest {
         assertEquals("[T][ ] Message", t.toString());
         t.markAsDone();
         assertEquals("[T][X] Message", t.toString());
+    }
+
+    @Test
+    public void testUpdate_validParams_success() {
+        try {
+            Todo t = new Todo("Message");
+            t.update(UpdateType.DESCRIPTION, "New Todo");
+            assertEquals("[T][ ] New Todo",
+                    t.toString());
+        } catch (DukeException e) {
+            fail("DukeException should not be thrown!");
+        }
+    }
+
+    @Test
+    public void testUpdate_invalidUpdateDate1_dukeExceptionThrown() {
+        try {
+            Todo t = new Todo("Message");
+            t.update(UpdateType.DESCRIPTION, "New Todo");
+            t.update(UpdateType.DATE1, "2023-10-10T12:00:01");
+            fail("DukeException should be thrown!");
+        } catch (DukeException e) {
+            assertEquals("Cannot update: Todos do not have dates!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUpdate_invalidUpdateDate2_dukeExceptionThrown() {
+        try {
+            Todo t = new Todo("Message");
+            t.update(UpdateType.DESCRIPTION, "New Todo");
+            t.update(UpdateType.DATE2, "2023-10-10T12:00:01");
+            fail("DukeException should be thrown!");
+        } catch (DukeException e) {
+            assertEquals("Cannot update: Todos do not have dates!", e.getMessage());
+        }
     }
 }

--- a/src/test/java/duke/task/TodoTest.java
+++ b/src/test/java/duke/task/TodoTest.java
@@ -66,4 +66,19 @@ public class TodoTest {
             assertEquals("Cannot update: Todos do not have dates!", e.getMessage());
         }
     }
+
+    @Test
+    public void testClone() {
+        try {
+            Todo t1 = new Todo("Message");
+            t1.markAsDone();
+            Todo t2 = t1.clone();
+            t2.update(UpdateType.DESCRIPTION, "New Message");
+
+            assertEquals("[T][X] Message", t1.toString());
+            assertEquals("[T][ ] New Message", t2.toString());
+        } catch (DukeException e) {
+            fail("DukeException should not be thrown!");
+        }
+    }
 }


### PR DESCRIPTION
Currently, while `update()` and `clone()` functionality has
been tested in the `TaskList` level, there is still a need to 
test them at the individual Task subclass (Todo, Deadline,
Event) level to improve testing.

Add several test cases to finalise JUnit automated testing:
- Several test cases for each `update()` method
- One bigger test case for each `clone()` method